### PR TITLE
fix: GitHub Pages styling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,8 @@ GEM
     eventmachine (1.2.7)
     ffi (1.16.3)
     forwardable-extended (2.6.0)
+    google-protobuf (4.26.1-arm64-darwin)
+      rake (>= 13)
     google-protobuf (4.26.1-x86_64-darwin)
       rake (>= 13)
     http_parser.rb (0.8.0)
@@ -63,6 +65,8 @@ GEM
     rexml (3.2.6)
     rouge (4.2.1)
     safe_yaml (1.0.5)
+    sass-embedded (1.72.0-arm64-darwin)
+      google-protobuf (>= 3.25, < 5.0)
     sass-embedded (1.72.0-x86_64-darwin)
       google-protobuf (>= 3.25, < 5.0)
     terminal-table (3.0.2)
@@ -71,6 +75,7 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-22
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ Serve locally
 bundle exec jekyll serve
 
 to fx dependencies: bundle update && bundle install
+
+### Taskfile
+
+There's also a [`Taskfile.yml`](./Taskfile.yml) file with the common local development commands. See https://taskfile.dev for more information on how to use it.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,10 @@
+# https://taskfile.dev
+
+version: "3"
+
+tasks:
+  install:
+    cmd: bundle install
+
+  dev:
+    cmd: bundle exec jekyll serve --livereload

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: "Vocabulary Derivation Modes Vocabulary"
 email: nicholas.car@anu.edu.au
 description: >- # this means to ignore newlines until "baseurl:"
   The modes by which one vocabulary may derive from another.
-baseurl: "/vocab-derivation-modes" # the subpath of your site, e.g. /blog
+baseurl: "/vocdermods" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll


### PR DESCRIPTION
The current GitHub Pages styling is broken. https://agldwg.github.io/vocdermods/

I am not 100% sure this will fix it, will only know once we merge this and test it in GitHub Pages.

Fix:
- fix: baseurl for github pages deployment

Misc.
- feat: add taskfile
- chore: add macOS arm deps

